### PR TITLE
RequestのEntityからServiceまでを実装

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,11 +58,11 @@
 			<version>1.18.8</version>
 			<scope>provided</scope>
 		</dependency>
-        <!--<dependency>
+        <dependency>
           <groupId>com.google.cloud</groupId>
           <artifactId>google-cloud-translate</artifactId>
           <version>1.85.0</version>
-        </dependency>-->
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -58,11 +58,11 @@
 			<version>1.18.8</version>
 			<scope>provided</scope>
 		</dependency>
-        <dependency>
+        <!--<dependency>
           <groupId>com.google.cloud</groupId>
           <artifactId>google-cloud-translate</artifactId>
           <version>1.85.0</version>
-        </dependency>
+        </dependency>-->
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/rakuten/internship/DemoApplication.java
+++ b/src/main/java/com/rakuten/internship/DemoApplication.java
@@ -14,15 +14,6 @@ import org.springframework.context.annotation.Bean;
 @SpringBootApplication
 public class DemoApplication {
 
-    @Bean
-    public GoogleCredential getGoogleCredential() throws FileNotFoundException, IOException {
-        /*GoogleCredential credential = GoogleCredential
-            .fromStream(new FileInputStream(System.getenv("GOOGLE_APPLICATION_CREDENTIALS")))
-            .createScoped(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"));
-        credential.refreshToken();*/
-        //return credential;
-        return null;
-    }
 
 	public static void main(String[] args) {
 		SpringApplication.run(DemoApplication.class, args);

--- a/src/main/java/com/rakuten/internship/DemoApplication.java
+++ b/src/main/java/com/rakuten/internship/DemoApplication.java
@@ -5,7 +5,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Arrays;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+/// import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -16,11 +16,12 @@ public class DemoApplication {
 
     @Bean
     public GoogleCredential getGoogleCredential() throws FileNotFoundException, IOException {
-        GoogleCredential credential = GoogleCredential
+        /*GoogleCredential credential = GoogleCredential
             .fromStream(new FileInputStream(System.getenv("GOOGLE_APPLICATION_CREDENTIALS")))
             .createScoped(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"));
-        credential.refreshToken();
-        return credential;
+        credential.refreshToken();*/
+        //return credential;
+        return null;
     }
 
 	public static void main(String[] args) {

--- a/src/main/java/com/rakuten/internship/entity/Request.java
+++ b/src/main/java/com/rakuten/internship/entity/Request.java
@@ -1,0 +1,37 @@
+package com.rakuten.internship.entity;
+
+import lombok.Data;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@Data
+public class Request {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private long id;
+
+    private String name;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String language;
+
+    @Column(nullable = false)
+    private String latitude;
+
+    @Column(nullable = false)
+    private String longitude;
+
+    // TODO file upload
+    private String image;
+
+    private boolean isSolved;
+}

--- a/src/main/java/com/rakuten/internship/repository/RequestRepository.java
+++ b/src/main/java/com/rakuten/internship/repository/RequestRepository.java
@@ -4,4 +4,5 @@ import com.rakuten.internship.entity.Request;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RequestRepository extends JpaRepository<Request, Long> {
+    Request findRequestById(final long id);
 }

--- a/src/main/java/com/rakuten/internship/repository/RequestRepository.java
+++ b/src/main/java/com/rakuten/internship/repository/RequestRepository.java
@@ -1,0 +1,7 @@
+package com.rakuten.internship.repository;
+
+import com.rakuten.internship.entity.Request;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RequestRepository extends JpaRepository<Request, Long> {
+}

--- a/src/main/java/com/rakuten/internship/service/RequestService.java
+++ b/src/main/java/com/rakuten/internship/service/RequestService.java
@@ -1,0 +1,26 @@
+package com.rakuten.internship.service;
+
+import com.rakuten.internship.entity.Request;
+import com.rakuten.internship.repository.RequestRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class RequestService {
+    private final RequestRepository repository;
+
+    public RequestService(final RequestRepository repository) {
+        this.repository = repository;
+    }
+
+    public List<Request> findAllRequests() {
+        return repository.findAll();
+    }
+
+    public Request findRequestById(final long id) {
+        return repository.findRequestById(id);
+    }
+}

--- a/src/main/java/com/rakuten/internship/service/RequestService.java
+++ b/src/main/java/com/rakuten/internship/service/RequestService.java
@@ -23,4 +23,8 @@ public class RequestService {
     public Request findRequestById(final long id) {
         return repository.findRequestById(id);
     }
+
+    public void save(final Request request) {
+        repository.save(request);
+    }
 }

--- a/src/main/java/com/rakuten/internship/service/TodoService.java
+++ b/src/main/java/com/rakuten/internship/service/TodoService.java
@@ -3,9 +3,9 @@ package com.rakuten.internship.service;
 import java.io.IOException;
 import java.util.List;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+/*import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.cloud.translate.Translate.TranslateOption;
-import com.google.cloud.translate.TranslateOptions;
+import com.google.cloud.translate.TranslateOptions;*/
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
@@ -31,10 +31,10 @@ public class TodoService {
 
     @Autowired
     private TodoRepository todoRepository;
-
+/*
     @Autowired
     private GoogleCredential credential;
-    
+ */
     @Autowired
     private Gson gson;
 
@@ -47,11 +47,12 @@ public class TodoService {
     }
 
     public String translate(Todo todo) {
-        return TranslateOptions.getDefaultInstance().getService()
+  /*      return TranslateOptions.getDefaultInstance().getService()
             .translate(todo.getText(),
                 TranslateOption.sourceLanguage(todo.getSourceLanguage()),
                 TranslateOption.targetLanguage(todo.getTargetLanguage()))
-            .getTranslatedText();
+            .getTranslatedText();*/
+        return "ほんにゃら";
     }
 
     public String translate2(Todo todo) throws JsonSyntaxException, ParseException, IOException, HttpException {
@@ -68,7 +69,7 @@ public class TodoService {
     private HttpPost createQueryHttpPost(Todo todo) {
         return new HttpPost("https://translation.googleapis.com/language/translate/v2") {{
             addHeader("Content-Type", "application/json; charset=UTF-8");
-            addHeader("Authorization", "Bearer " + credential.getAccessToken());
+       //     addHeader("Authorization", "Bearer " + credential.getAccessToken());
             setEntity(new StringEntity(gson.toJson(createQueryJsonObject(todo)), "UTF-8"));
         }};
     }


### PR DESCRIPTION
# やったこと
タイトルの通り

# 実装メソッド
- `findAll` : 全てのRequestをListで返す
- `findRequestById` : idに該当するRequestを返す
- `save` : 与えられたRequestを保存する